### PR TITLE
Do not auto add "API documentation" to the title

### DIFF
--- a/index.nunjucks
+++ b/index.nunjucks
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
   <head>
-    <title>{{ title }} API documentation</title>
+    <title>{{ title }}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="generator" content="https://github.com/raml2html/raml2html {{ config.raml2HtmlVersion }}">
@@ -191,7 +191,7 @@
       <div class="row">
         <div class="col-md-9" role="main">
           <div class="page-header">
-            <h1>{{ title }} API documentation{% if version %} <small>version {{ version }}</small>{% endif %}</h1>
+            <h1>{{ title }}{% if version %} <small>version {{ version }}</small>{% endif %}</h1>
             <p>{{ baseUri }}</p>
 
             {% if description %}


### PR DESCRIPTION
Because in general case it could be not api (e.g. some service documentation)